### PR TITLE
stop loading of pry unless in console

### DIFF
--- a/lib/pry-rails.rb
+++ b/lib/pry-rails.rb
@@ -1,11 +1,5 @@
 # encoding: UTF-8
 
-require 'pry'
-require 'pry-rails/version'
-
 if defined?(Rails) && !ENV['DISABLE_PRY_RAILS']
   require 'pry-rails/railtie'
-  require 'pry-rails/commands'
-  require 'pry-rails/model_formatter'
-  require 'pry-rails/prompt'
 end

--- a/lib/pry-rails/railtie.rb
+++ b/lib/pry-rails/railtie.rb
@@ -4,7 +4,10 @@ module PryRails
   class Railtie < Rails::Railtie
     console do
       require 'pry'
+      require 'pry-rails/version'
       require 'pry-rails/commands'
+      require 'pry-rails/model_formatter'
+      require 'pry-rails/prompt'
 
       if Rails::VERSION::MAJOR == 3
         Rails::Console::IRB = Pry


### PR DESCRIPTION
Text below is from kwstannard

I would like to have pry-rails in every environment, but some people
don't like the idea of adding a bunch of useless file loading to
production.

Add this to config/application.rb to check what is loaded after bundler
require:

```
  # Require the gems listed in Gemfile, including any gems
  # you've limited to :test, :development, or :production.
  Bundler.require(*Rails.groups)

+ print "\npry features loaded: "
+ puts $LOADED_FEATURES.grep(/pry/).count

  module LoadTest
```

Current master:

```
$ bundle exec rails s

pry features loaded: 144
```

With this commit:

```
$ bundle exec rails s

pry features loaded: 4
```